### PR TITLE
Fixing content length

### DIFF
--- a/lib/GRNOC/WebService/Method.pm
+++ b/lib/GRNOC/WebService/Method.pm
@@ -16,7 +16,6 @@ use JSON::XS;
 use Clone;
 use Encode;
 use GRNOC::Config;
-use bytes;
 
 package GRNOC::WebService::Method;
 
@@ -1371,10 +1370,10 @@ sub _return_results{
         $answer = $self->{'output_formatter'}($results);
         if (! $explicit_headers){
             if ($all_headers->{'type'} =~ /^(application|text)\//) {
-                $all_headers->{'content_length'} = bytes:length($answer);
+                $all_headers->{'content_length'} = length($answer);
             }
             else {
-                $all_headers->{'content_length'} = bytes:length($answer);
+                $all_headers->{'content_length'} = length($answer);
             }
         }
     }

--- a/lib/GRNOC/WebService/Method.pm
+++ b/lib/GRNOC/WebService/Method.pm
@@ -1,11 +1,6 @@
 #--------------------------------------------------------------------
 #----- Copyright(C) 2013 The Trustees of Indiana University
 #--------------------------------------------------------------------
-#----- $LastChangedBy: mrmccrac $
-#----- $LastChangedRevision: 33346 $
-#----- $LastChangedDate: 2014-10-02 15:01:27 +0000 (Thu, 02 Oct 2014) $
-#----- $HeadURL: svn+ssh://svn.grnoc.iu.edu/grnoc/perl-lib/GRNOC-WebService/trunk/lib/GRNOC/WebService/Method.pm $
-#----- $Id: Method.pm 33346 2014-10-02 15:01:27Z mrmccrac $
 #-----
 #----- object oriented backend web service interface for core data services
 #-----

--- a/lib/GRNOC/WebService/Method.pm
+++ b/lib/GRNOC/WebService/Method.pm
@@ -21,7 +21,7 @@ use JSON::XS;
 use Clone;
 use Encode;
 use GRNOC::Config;
-
+use bytes;
 
 package GRNOC::WebService::Method;
 
@@ -1376,10 +1376,10 @@ sub _return_results{
         $answer = $self->{'output_formatter'}($results);
         if (! $explicit_headers){
             if ($all_headers->{'type'} =~ /^(application|text)\//) {
-                $all_headers->{'content_length'} = length(Encode::encode('UTF-8', $answer));
+                $all_headers->{'content_length'} = bytes:length($answer);
             }
             else {
-                $all_headers->{'content_length'} = length($answer);
+                $all_headers->{'content_length'} = bytes:length($answer);
             }
         }
     }

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 2;
 use GRNOC::WebService;
 use JSON::XS;
 use URI::Escape qw(uri_escape_utf8) ;
@@ -32,6 +32,7 @@ my $method = GRNOC::WebService::Method->new( name => "string_echo",
 
 $method->add_input_parameter( name => 'string',
 			      pattern => '^([[:print:][:space:]]+)$',
+			      #pattern => '^(.*)$',
 			      required => 1,
 			      description => "string input" );
 
@@ -42,6 +43,18 @@ $svc->register_method( $method );
 $svc->handle_request();
 
 my @input = split(/\n/, $output);
+
+my $length;
+
+foreach my $line (@input){
+    if($line =~ /Content-length: (\d+)/){
+	$length = $1;
+    }
+}
+
+my $content_length = length ($input[ scalar(@input) - 1 ]);
+
+ok($content_length == $length, "Length matches content length");
 
 my $struct = JSON::XS::decode_json( $input[ scalar(@input) - 1 ] );
 


### PR DESCRIPTION
There was an issue with determining the content length of the response because the response was already encoded UTF-8 and we were then re-encoding it as UTF-8 which could potentially add additional characters (ie... length) causing a failure to be reported in the browser even though all of the content was sent.  I also added a unit test to verify this functions properly.