### PR TITLE
SCTASK1001695 cgi param to multi param

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+GRNOC::WebService v1.2.17 -- Thu Feb 12 2026
+============================================
+
+* SCTASK1001695 $cgi->param($param); is now $cgi->multi_param($param);. This resolves the error message: 'CGI::param called in list context from .../GRNOC/WebService/Method.pm line 625, this can lead to vulnerabilities. See the warning in "Fetching the value or values of a single named parameter". .../vendor_perl/CGI.pm line 412.'
+
 GRNOC::WebService v1.2.16 -- Wed Jan 28 2026
 ============================================
 

--- a/lib/GRNOC/WebService.pm
+++ b/lib/GRNOC/WebService.pm
@@ -9,7 +9,7 @@ use strict;
 
 package GRNOC::WebService;
 
-our $VERSION = '1.2.16';
+our $VERSION = '1.2.17';
 
 require GRNOC::WebService::Dispatcher;
 require GRNOC::WebService::Method;

--- a/lib/GRNOC/WebService/Method.pm
+++ b/lib/GRNOC/WebService/Method.pm
@@ -622,7 +622,8 @@ sub _parse_input_parameters {
       $multipart = 1;
     }
 
-    my @input_array = $cgi->param($param);
+    my @input_array = $cgi->multi_param($param);
+
     my $input_cnt = scalar @input_array;
 
     if ($input_cnt == 0) {

--- a/perl-GRNOC-WebService.spec
+++ b/perl-GRNOC-WebService.spec
@@ -1,5 +1,5 @@
 Name:           perl-GRNOC-WebService
-Version:        1.2.16
+Version:        1.2.17
 Release:        1%{?dist}
 Summary:        GRNOC WebService Library for perl
 License:        CHECK(Distributable)


### PR DESCRIPTION
Fixes this error:

> CGI::param called in list context from .../GRNOC/WebService/Method.pm line 625, this can lead to vulnerabilities. See the warning in "Fetching the value or values of a single named parameter" at .../vendor_perl/CGI.pm line 412.